### PR TITLE
[hotfix] Wordpress

### DIFF
--- a/apps/linode-marketplace-wordpress/roles/wordpress/tasks/main.yml
+++ b/apps/linode-marketplace-wordpress/roles/wordpress/tasks/main.yml
@@ -51,10 +51,26 @@
     mode: 0755
   register: wpcli
 
-- name: downloading wordpress lastest
-  shell:
-    chdir: "/var/www/{{ _domain }}/public_html"
-    cmd: wp core download --allow-root
+#- name: downloading wordpress lastest
+#  shell:
+#    chdir: "/var/www/{{ _domain }}/public_html"
+#    cmd: wp core download --allow-root
+
+- name: downloading wordpress latest
+  get_url:
+    url: https://wordpress.org/latest.tar.gz
+    dest: /tmp/latest.tar.gz
+    group: root
+    owner: root
+    mode: 0755
+
+- name: unzip wp-latest
+  ansible.builtin.unarchive:
+    src: /tmp/latest.tar.gz
+    dest: "/var/www/{{ _domain }}/public_html"
+    owner: root
+    group: root
+    mode: 0755
 
 - name: configuring wordpress site
   shell:

--- a/apps/linode-marketplace-wordpress/roles/wordpress/tasks/main.yml
+++ b/apps/linode-marketplace-wordpress/roles/wordpress/tasks/main.yml
@@ -67,7 +67,16 @@
 - name: unzip wp-latest
   ansible.builtin.unarchive:
     src: /tmp/latest.tar.gz
-    dest: "/var/www/{{ _domain }}/public_html"
+    dest: "/tmp"
+    owner: root
+    group: root
+    mode: 0755
+
+- name: moving WP to document root
+  ansible.builtin.copy:
+    src: /tmp/wordpress 
+    dest: "/var/www/{{ _domain }}/public_html/"
+    remote_src: yes
     owner: root
     group: root
     mode: 0755
@@ -76,7 +85,7 @@
   shell:
     chdir: "/var/www/{{ _domain }}/public_html"
     cmd: |
-      wp core config --allow-root --path="/var/www/{{ _domain }}/public_html" \
+      wp core config --allow-root \
         --dbhost="localhost" \
         --dbname="{{ wp_db_name }}" \
         --dbuser="{{ wp_db_user }}" \
@@ -86,7 +95,7 @@
   shell:
     chdir: "/var/www/{{ _domain }}/public_html"
     cmd: |
-      wp core install --allow-root --path="/var/www/{{ _domain }}/public_html" \
+      wp core install --allow-root \
           --url="{{ _domain }}" \
           --title="{{ site_title }}" \
           --admin_user="{{ wp_admin_user }}" \

--- a/apps/linode-marketplace-wordpress/roles/wordpress/tasks/main.yml
+++ b/apps/linode-marketplace-wordpress/roles/wordpress/tasks/main.yml
@@ -76,7 +76,7 @@
   shell:
     chdir: "/var/www/{{ _domain }}/public_html"
     cmd: |
-      wp core config --allow-root \
+      wp core config --allow-root --path="/var/www/{{ _domain }}/public_html" \
         --dbhost="localhost" \
         --dbname="{{ wp_db_name }}" \
         --dbuser="{{ wp_db_user }}" \
@@ -86,7 +86,7 @@
   shell:
     chdir: "/var/www/{{ _domain }}/public_html"
     cmd: |
-      wp core install --allow-root \
+      wp core install --allow-root --path="/var/www/{{ _domain }}/public_html" \
           --url="{{ _domain }}" \
           --title="{{ site_title }}" \
           --admin_user="{{ wp_admin_user }}" \

--- a/apps/linode-marketplace-wordpress/roles/wordpress/tasks/main.yml
+++ b/apps/linode-marketplace-wordpress/roles/wordpress/tasks/main.yml
@@ -74,8 +74,8 @@
 
 - name: moving WP to document root
   ansible.builtin.copy:
-    src: /tmp/wordpress 
-    dest: "/var/www/{{ _domain }}/public_html/"
+    src: /tmp/wordpress/ 
+    dest: "/var/www/{{ _domain }}/public_html"
     remote_src: yes
     owner: root
     group: root


### PR DESCRIPTION
a SSL error prevented curl from pulling wp cli. We're going to manually download and move WP files for now.